### PR TITLE
Add optional PostImportScriptPath parameter to lazy-posh-git module to enable running custom script after posh-git import

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Import-Module 'lazy-posh-git'
 
 Only once you navigate to a git directory, the `posh-git` module will be imported, which is when it is needed, therefore defering the delay caused by the import to the last moment in time until we know we need it.
 
-## Using custom posh-git settings
-If there are certain posh-git settings you wish to change after posh-git is loaded, you can do so. Create a script file with the desired settings in a convenient location. Then tell lazy-posh-git where to find it, like this:
+## Using custom posh-git settings or running a custom script after import
+
+If there are certain `posh-git` settings you wish to change after `posh-git` is imported or running a custom script after import, you can do so by passing the path to a script as the first argument to the `PoshGitSettingsScriptPath` parameter when importing `lazy-posh-git`:
 
 ```powershell
 Import-Module 'lazy-posh-git' -ArgumentList '~\path-to-my\git-prompt-settings.ps1'
 ``` 
 
-Lazy-posh-git will run your script directly after it has loaded posh-git. Your posh-git settings script could look like this for example:
+`Lazy-posh-git` will run this script immediately after it has imported `posh-git`. The path can be absolute or relative depending on the assumptions you can make. Your script could look like this for example:
 
 ```powershell
 $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory = $true

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Import-Module 'lazy-posh-git'
 
 Only once you navigate to a git directory, the `posh-git` module will be imported, which is when it is needed, therefore defering the delay caused by the import to the last moment in time until we know we need it.
 
+## Using custom posh-git settings
+If there are certain posh-git settings you wish to change after posh-git is loaded, you can do so. Create a script file with the desired settings in a convenient location. Then tell lazy-posh-git where to find it, like this:
+
+```powershell
+Import-Module 'lazy-posh-git' -ArgumentList '~\path-to-my\git-prompt-settings.ps1'
+``` 
+
+Lazy-posh-git will run your script directly after it has loaded posh-git. Your posh-git settings script could look like this for example:
+
+```powershell
+$GitPromptSettings.DefaultPromptAbbreviateHomeDirectory = $true
+$GitPromptSettings.AfterStatus.Text = "]`n"
+```
+
 ## Support
 
 Currently, this early version only supports PowerShell 7.0 and later. If you need support for PowerShell 5.1, please open an issue or open a pull request.

--- a/lazy-posh-git.psm1
+++ b/lazy-posh-git.psm1
@@ -3,7 +3,8 @@
     .ForwardHelpCategory Cmdlet
 #>
 param(
-    [string] $PoshGitSettingsScriptPath
+    [Parameter(Position = 0)]
+    [string] $PostImportScriptPath
 )
 
 function Set-Location {
@@ -85,8 +86,8 @@ function Set-Location {
         }
         if (Test-Path (Join-Path $PWD.Path '.git')) {
             Import-Module posh-git
-            if (Test-Path $PoshGitSettingsScriptPath) {
-                & $PoshGitSettingsScriptPath
+            if (Test-Path $PostImportScriptPath) {
+                & $PostImportScriptPath
             }
         }
     }

--- a/lazy-posh-git.psm1
+++ b/lazy-posh-git.psm1
@@ -2,6 +2,10 @@
     .ForwardHelpTargetName Microsoft.PowerShell.Management\Set-Location
     .ForwardHelpCategory Cmdlet
 #>
+param(
+    [string] $PoshGitSettingsScriptPath
+)
+
 function Set-Location {
     [CmdletBinding(DefaultParameterSetName = 'Path', HelpUri = 'https://go.microsoft.com/fwlink/?LinkID=2097049')]
     param(
@@ -81,6 +85,9 @@ function Set-Location {
         }
         if (Test-Path (Join-Path $PWD.Path '.git')) {
             Import-Module posh-git
+            if (Test-Path $PoshGitSettingsScriptPath) {
+                & $PoshGitSettingsScriptPath
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1

This PR is intended to come up with the best solution to enable lazy-posh-git to load additional settings, after posh-git is imported.

Please feel free to make improvements, or suggestions. 