### PR TITLE
Fix Powershell 5 compatibility

### DIFF
--- a/lazy-posh-git.psd1
+++ b/lazy-posh-git.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) Christoph Bergmeister. All rights reserved.'
 Description = 'Proxy command around Set-Location and its aliases to defer import of posh-git until one is in a git directory.'
 
 # Minimum version of the PowerShell engine required by this module
- PowerShellVersion = '7.0'
+ PowerShellVersion = '5.0'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/lazy-posh-git.psm1
+++ b/lazy-posh-git.psm1
@@ -86,7 +86,8 @@ function Set-Location {
         }
         if (Test-Path (Join-Path $PWD.Path '.git')) {
             Import-Module posh-git
-            if (Test-Path $PostImportScriptPath) {
+            # The first condition helps to prevent ParameterBindingException on PowerShell 5
+            if ($PostImportScriptPath -and $(Test-Path $PostImportScriptPath)) {
                 & $PostImportScriptPath
             }
         }


### PR DESCRIPTION
Since posh-git supports PowerShell version 5 and greater and Windows ships with PowerShell version 5, it would be great for lazy-posh-git to support it too.